### PR TITLE
Fix MemStorage default behaviour

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -243,8 +243,10 @@ export class MemStorage implements IStorage {
   private compartmentIdCounter = 1;
   private componentIdCounter = 1;
 
-  constructor() {
-    this.initializeDefaultData();
+  constructor(options?: { initDefaultData?: boolean }) {
+    if (options?.initDefaultData) {
+      this.initializeDefaultData();
+    }
   }
 
   private initializeDefaultData() {


### PR DESCRIPTION
## Summary
- make `MemStorage` start empty unless `initDefaultData` is passed

## Testing
- `npm test --silent` *(fails: tsx not found)*